### PR TITLE
increased the ticker interval

### DIFF
--- a/lib/sse.js
+++ b/lib/sse.js
@@ -181,11 +181,13 @@ function handler(config, req, reply) {
 
                 let ping = 0
                 const tickerStream = Rx.Observable
-                    .interval(100)
+                    .interval(5000)
                     .map(() => {
                         return {event: 'ticker', id: ping, data: ping++}
                     })
                     .subscribe(subject)
+
+                reply.event('\n')
 
                 const eventReplyStream = subject
                     .subscribe(


### PR DESCRIPTION
ticker interval was set at 100ms, raised it to 5s
added reply.event('\n') to get the initial headers sent back as part of the response, without having to rely on the ticker