### PR TITLE
remove side effects from route builders 

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -39,18 +39,6 @@ exports.register = function (server, opts, next) {
 
             const appendLinkedResources = includes(server, adapter, schemas).appendLinkedResources;
 
-            const onRouteRegister = function (schema, createRelationshipsRoutesRead, createRelationshipsRoutesWrite) {
-                routeUtils.createOptionsRoute(server, schema)
-                if (createRelationshipsRoutesRead) {
-                    routeUtils.createRelationshipsRoutesRead(server, schema)
-                }
-                if (createRelationshipsRoutesWrite) {
-                    routeUtils.createRelationshipsRoutesWrite(server, schema)
-                }
-                adapter.processSchema(schema)
-                schemas[schema.type] = schema
-            }
-
             const get = function (schema) {
                 onRouteRegister(schema);
                 return _.merge(routes.get(schema), {
@@ -73,8 +61,9 @@ exports.register = function (server, opts, next) {
             }
 
             const getById = function (schema) {
-                onRouteRegister(schema, true)
-                return _.merge(routes.getById(schema), {
+                onRouteRegister(schema)
+
+                var getByIdRoute = _.merge(routes.getById(schema), {
                     handler: (req, reply) => {
                         reply(adapter.findById(schema.type, req.params.id, extractFields(req, schema)).then((found)=> {
                             if (found) {
@@ -85,6 +74,8 @@ exports.register = function (server, opts, next) {
                         }))
                     }
                 })
+
+                return routeUtils.createRelationshipsRoutesRead(adapter, schema).concat(getByIdRoute)
             }
 
             function extractFields(query, schema) {
@@ -108,7 +99,7 @@ exports.register = function (server, opts, next) {
             }
 
             const post = function (schema) {
-                onRouteRegister(schema, true, true);
+                onRouteRegister(schema)
                 return _.merge(routes.post(schema), {
                     handler: (req, reply) => {
                         reply(adapter.create(schema.type, req.payload.data).then((data)=> {
@@ -119,8 +110,8 @@ exports.register = function (server, opts, next) {
             }
 
             const patch = function (schema) {
-                onRouteRegister(schema, true, true);
-                return _.merge(routes.patch(schema), {
+                onRouteRegister(schema)
+                const patchRoute = _.merge(routes.patch(schema), {
                     handler: (req, reply) => {
                         reply(adapter.update(schema.type, req.params.id, req.payload.data).then((found)=> {
                             if (found) {
@@ -131,10 +122,11 @@ exports.register = function (server, opts, next) {
                         }))
                     }
                 })
+                return routeUtils.createRelationshipsRoutesWrite(adapter, schema).concat(patchRoute)
             }
 
             const del = function (schema) {
-                onRouteRegister(schema, true, true);
+                onRouteRegister(schema)
                 return _.merge(routes.delete(schema), {
                     handler: (req, reply) => {
                         reply(adapter.delete(schema.type, req.params.id)).code(204)
@@ -142,41 +134,83 @@ exports.register = function (server, opts, next) {
                 })
             }
 
+            const options = function (schema) {
+                onRouteRegister(schema)
+                return _.merge(routes.options(schema), {
+                    handler: (req, reply) => {
+                        const tables = _.map(req.server.table()[0].table, (table) => {
+                            return _.pick(table, 'path', 'method')
+                        })
+
+                        const pathVerbs = _.chain(tables)
+                            .filter((table) => {
+                                return table.path.replace('/{id}', '') === req.path
+                            })
+                            .pluck('method')
+                            .map((verb) => {
+                                return verb.toUpperCase()
+                            })
+                            .value();
+
+                        reply().header('Allow', pathVerbs.join(','))
+                    }
+                })
+            }
+
+            const onRouteRegister = function (schema) {
+                adapter.processSchema(schema)
+                schemas[schema.type] = schema
+            }
+
+
             const routehandlers = {
                 get: get,
                 getById: getById,
                 getChangesStreaming: getChangesStreaming,
                 post: post,
                 patch: patch,
-                delete: del
+                delete: del,
+                options: options
             }
 
-            const allLabels = ['get', 'getById', 'getChangesStreaming', 'post', 'patch', 'delete']
+            const allLabels = ['get', 'getById', 'getChangesStreaming', 'post', 'patch', 'delete', 'options']
 
             const all = function (schema) {
-                return _.map(allLabels, (routeLabel)=> {
-                    return routehandlers[routeLabel](schema)
-                })
+                return _.chain(allLabels)
+                    .map((routeLabel)=> {
+                        return routehandlers[routeLabel](schema)
+                    })
+                    .flatten()
+                    .value()
             }
 
             const pick = function (schema, routeLabels) {
-                return _.map(routeLabels, (routeLabel)=> {
-                    var routehandler = routehandlers[routeLabel];
-                    Hoek.assert(routehandler, `illegal routeLabel : '${routeLabel}', allowed labels are : ${allLabels.join(', ')}`)
-                    return routehandler(schema)
-                })
+                return _.chain(routeLabels)
+                    .map((routeLabel)=> {
+                        var routehandler = routehandlers[routeLabel];
+                        Hoek.assert(routehandler, `illegal routeLabel : '${routeLabel}', allowed labels are : ${allLabels.join(', ')}`)
+                        return routehandler(schema)
+                    })
+                    .flatten()
+                    .value()
             }
 
             const readonly = function (schema) {
-                return _.map(['get', 'getById', 'getChangesStreaming'], (routeLabel)=> {
-                    return routehandlers[routeLabel](schema)
-                })
+                return _.chain(['get', 'getById', 'getChangesStreaming', 'options'])
+                    .map((routeLabel)=> {
+                        return routehandlers[routeLabel](schema)
+                    })
+                    .flatten()
+                    .value()
             }
 
             const immutable = function (schema) {
-                return _.map(['get', 'getById', 'getChangesStreaming', 'post'], (routeLabel)=> {
-                    return routehandlers[routeLabel](schema)
-                })
+                return _.chain(['get', 'getById', 'getChangesStreaming', 'post', 'options'])
+                    .map((routeLabel)=> {
+                        return routehandlers[routeLabel](schema)
+                    })
+                    .flatten()
+                    .value()
             }
 
             server.expose('routes', _.merge(routehandlers, {

--- a/lib/utils/route.js
+++ b/lib/utils/route.js
@@ -3,64 +3,25 @@
 const _ = require('lodash')
 const routes = require('../routes')()
 
-module.exports = function() {
+module.exports = function () {
 
-    const createOptionsRoute = function(server, schema) {
-        const tables = _.map(server.table()[0].table)
+    const createRelationshipsRoutesRead = function (adapter, schema) {
 
-        //see if the options method already exists, if so, don't duplicate it
-        if (_.find(tables, {path : '/' + schema.type, method: 'options'})) return;
-
-        server.route(_.merge(routes.options(schema), {
-            handler: (req, reply) => {
-                const tables = _.map(req.server.table()[0].table, (table) => {
-                    return _.pick(table, 'path', 'method')
-                })
-
-                const pathVerbs = _.chain(tables)
-                .filter((table) => {
-                    return table.path.replace('/{id}', '') === req.path
-                })
-                .pluck('method')
-                .map((verb) => { return verb.toUpperCase() })
-                .value();
-
-                reply().header('Allow', pathVerbs.join(','))
-            }
-        }))
-    }
-
-    const isRouteRegistered = function (server, route) {
-        return _.any(server.table(), function (item) {
-            return _.any(item.table, function (registeredRoute) {
-                return registeredRoute.path.toLowerCase() === route.path.toLowerCase() && registeredRoute.method.toLowerCase() === route.method.toLowerCase();
-            });
-        });
-    }
-
-    const createRelationshipsRoutesRead = function (server, schema) {
         const getById = function (relationshipName) {
-            return _.merge(routes.getByIdRelationships(schema, relationshipName), {config: schema.config}, {
+            return _.merge(routes.getByIdRelationships(schema, relationshipName), {
                 handler: (req, reply) => {
                     reply({data: adapter.findById(schema.type, req)})
                 }
             })
         }
-        _.forEach(schema.relationships, function (relationshipSpec, relationshipName) {
-            _.forEach([getById], function (routeFactory) {
-                const route = routeFactory(relationshipName);
-                if (!isRouteRegistered(server, route)) {
-                    server.route(route)
-                }
-            })
-        });
+
+        return mapRelationshipsToRoutes(schema, [getById])
     }
 
-    const createRelationshipsRoutesWrite = function (server, schema) {
-        const adapter = server.plugins['hapi-harvester'].adapter
+    const createRelationshipsRoutesWrite = function (adapter, schema) {
 
         const patch = function (relationshipName) {
-            return _.merge(routes.patchByIdRelationships(schema, relationshipName), {config: schema.config}, {
+            return _.merge(routes.patchByIdRelationships(schema, relationshipName), {
                 handler: function (req, reply) {
                     reply(adapter.findById(schema.type, req.params.id).then(function (result) {
                         result.relationships[relationshipName] = req.payload.data
@@ -68,13 +29,12 @@ module.exports = function() {
                     }).then(function () {
                         return {}
                     })).code(204)
-
                 }
             })
         }
 
         const post = function (relationshipName) {
-            return _.merge(routes.postByIdRelationships(schema, relationshipName), {config: schema.config}, {
+            return _.merge(routes.postByIdRelationships(schema, relationshipName), {
                 handler: function (req, reply) {
                     if (!_.isArray(schema.relationships[relationshipName])) {
                         reply().code(403)
@@ -93,7 +53,7 @@ module.exports = function() {
         }
 
         const deleteItem = function (relationshipName) {
-            return _.merge(routes.deleteByIdRelationships(schema, relationshipName), {config: schema.config}, {
+            return _.merge(routes.deleteByIdRelationships(schema, relationshipName), {
                 handler: function (req, reply) {
                     reply(adapter.findById(schema.type, req.params.id).then(function (result) {
                         result.relationships[relationshipName] = null
@@ -105,30 +65,34 @@ module.exports = function() {
             })
         }
 
-        _.forEach(schema.relationships, function (relationshipSpec, relationshipName) {
-            _.forEach([patch, post, deleteItem], function (routeFactory) {
-                const route = routeFactory(relationshipName);
-                if (!isRouteRegistered(server, route)) {
-                    server.route(route)
-                }
-            })
-        });
+        return mapRelationshipsToRoutes(schema, [patch, post, deleteItem])
 
     }
 
-    const parseComparators = function(req) {
+    function mapRelationshipsToRoutes(schema, routeFactories) {
+        return _.chain(schema.relationships)
+            .map((relationshipSpec, relationshipName) => {
+                return _.map(routeFactories, function (routeFactory) {
+                    return routeFactory(relationshipName)
+                })
+            })
+            .flatten()
+            .value();
+    }
+
+    const parseComparators = function (req) {
         const supportedComparators = ['lt', 'lte', 'gt', 'gte']
 
         req.query.filter && _.each(req.query.filter, (filter, key) => {
             const split = filter.split('=')
 
-            if (split.length > 1 &&  _.contains(supportedComparators, split[0])) {
-                req.query.filter[key] = {[split[0]] : split[1]}
+            if (split.length > 1 && _.contains(supportedComparators, split[0])) {
+                req.query.filter[key] = {[split[0]]: split[1]}
             }
         })
 
         return req
     }
 
-    return {createOptionsRoute, createRelationshipsRoutesRead, createRelationshipsRoutesWrite, parseComparators}
+    return {createRelationshipsRoutesRead, createRelationshipsRoutesWrite, parseComparators}
 }

--- a/test/plugin.spec.js
+++ b/test/plugin.spec.js
@@ -39,9 +39,7 @@ describe('Plugin Basics', function () {
 
     it('only sends the available verbs on OPTIONS call', function () {
 
-        ['get', 'post', 'patch', 'delete'].forEach(function (verb) {
-            server.route(server.plugins['hapi-harvester'].routes[verb](schema))
-        })
+        server.route(server.plugins['hapi-harvester'].routes.pick(schema, ['get', 'post', 'patch', 'delete', 'options']))
 
         return server.injectThen({method: 'OPTIONS', url: '/brands'})
             .then(function (res) {

--- a/test/utils.js
+++ b/test/utils.js
@@ -38,23 +38,15 @@ var utils = {
                 let harvester = server.plugins['hapi-harvester'];
                 server.start(() => {
                     _.forEach(schemas, function (schema) {
-                        [
-                            'get',
-                            'getById',
-                            'getChangesStreaming',
-                            'post',
-                            'patch',
-                            'delete'
-                        ].forEach(function (verb) {
-                            const route = harvester.routes[verb](schema)
-                            if (_.isArray(route)) {
-                                _.forEach(route, function (route) {
-                                    server.route(route)
-                                });
-                            } else {
+
+                        const route = harvester.routes.all(schema)
+                        if (_.isArray(route)) {
+                            _.forEach(route, function (route) {
                                 server.route(route)
-                            }
-                        })
+                            });
+                        } else {
+                            server.route(route)
+                        }
 
                     });
                     resolve({server, harvester})
@@ -71,16 +63,16 @@ var utils = {
     },
     createDefaultServerDestructor: function () {
         return function () {
-        return new Promise(function (resolve, reject) {
-            server.stop(function (err) {
-                if (err) {
-                    reject(err);
-                } else {
-                    resolve();
-                }
-            })
-        });
-    }
+            return new Promise(function (resolve, reject) {
+                server.stop(function (err) {
+                    if (err) {
+                        reject(err);
+                    } else {
+                        resolve();
+                    }
+                })
+            });
+        }
     }
 };
 


### PR DESCRIPTION
getById and patch now return an array of routes rather than a single route. it no longer registers the routes directly in the server as a side effect

options is a seperate routeHandler, the hapi-harvester user needs to call it explicitly and register it within the server. it also no longer gets autocreated in the server as a side effect

routes .all, .readonly, .immutable and .pick return a flattened array of the individual routes, the applicable relationship routes and the options routes