### PR TITLE
#33 Disable 'required' field rules for PATCHes

### DIFF
--- a/lib/adapters/mongodb/index.js
+++ b/lib/adapters/mongodb/index.js
@@ -105,7 +105,6 @@ module.exports = function (mongodbUrl, options) {
     const patch = function(type, id, data) {
         const model = models[type]
         const patchObject = extendPatch({}, data, '');
-        console.log(patchObject);
         return model.findByIdAndUpdate(id, patchObject)
         .then((resource) => {
             if (!resource) {

--- a/lib/adapters/mongodb/index.js
+++ b/lib/adapters/mongodb/index.js
@@ -89,6 +89,30 @@ module.exports = function (mongodbUrl, options) {
                 }
                 return findById(type, id)
             })
+        }
+
+    const extendPatch = function(patch, data, parent) {
+        Object.keys(data).forEach(function(key){
+            if (typeof data[key] === 'object') {
+                patch = extendPatch(patch, data[key], parent + key + '.');
+            } else {
+                patch[parent + key] = data[key];
+            }
+        })
+        return patch;
+    }
+
+    const patch = function(type, id, data) {
+        const model = models[type]
+        const patchObject = extendPatch({}, data, '');
+        console.log(patchObject);
+        return model.findByIdAndUpdate(id, patchObject)
+        .then((resource) => {
+            if (!resource) {
+                return null
+            }
+            return findById(type, id)
+        })
     }
 
     const del = function (type, id) {
@@ -115,6 +139,7 @@ module.exports = function (mongodbUrl, options) {
         options,
         create,
         update,
+        patch,
         delete: del,
         models,
         processSchema

--- a/lib/adapters/mongodb/index.js
+++ b/lib/adapters/mongodb/index.js
@@ -6,6 +6,7 @@ const Converters = require('./converters');
 const debug = require('debug')('hh-adapter')
 const Promise = require('bluebird')
 const Hoek = require('hoek')
+const dot = require('dot-object');
 
 const connection = require('./connection')
 
@@ -89,22 +90,11 @@ module.exports = function (mongodbUrl, options) {
                 }
                 return findById(type, id)
             })
-        }
-
-    const extendPatch = function(patch, data, parent) {
-        Object.keys(data).forEach(function(key){
-            if (typeof data[key] === 'object') {
-                patch = extendPatch(patch, data[key], parent + key + '.');
-            } else {
-                patch[parent + key] = data[key];
-            }
-        })
-        return patch;
     }
 
     const patch = function(type, id, data) {
         const model = models[type]
-        const patchObject = extendPatch({}, data, '');
+        const patchObject = dot.dot(data);
         return model.findByIdAndUpdate(id, patchObject)
         .then((resource) => {
             if (!resource) {

--- a/lib/adapters/mongodb/sse/index.js
+++ b/lib/adapters/mongodb/sse/index.js
@@ -8,6 +8,7 @@ const RxNode = require('rx-node')
 const mongo = require('mongoose/node_modules/mongodb')
 const mongoose = require('mongoose')
 const Boom = require('boom')
+const dot = require('dot-object');
 
 const connection = require('../connection')
 
@@ -153,23 +154,6 @@ module.exports = function (mongodbOplogUrl, options) {
         return mongoEntity
     }
 
-    function uncollapseSetObject(obj) {
-        const o = {};
-        Object.keys(obj).forEach((key) => {
-            const keysInKeyString = key.split('.');
-            const firstKey = keysInKeyString[0];
-            if (keysInKeyString.length === 1) {
-              o[firstKey] = obj[firstKey];
-            } else {
-                const restOfKeyString = key.substring(key.indexOf('.') + 1);
-                o[firstKey] = o[firstKey] || {};
-                o[firstKey][restOfKeyString] = obj[key];
-                o[firstKey] = uncollapseSetObject(o[firstKey]);
-            }
-        })
-        return o;
-    }
-
     function getData(chunk) {
         var data
         switch (chunk.op) {
@@ -177,7 +161,7 @@ module.exports = function (mongodbOplogUrl, options) {
                 data = deserialize(chunk.o)
                 break
             case 'u' :
-                data = uncollapseSetObject(chunk.o.$set, {});
+                data = dot.object(chunk.o.$set);
                 if (!data.id && chunk.o2 && chunk.o2._id) {
                     data.id = chunk.o2._id
                 }

--- a/lib/adapters/mongodb/sse/index.js
+++ b/lib/adapters/mongodb/sse/index.js
@@ -153,15 +153,31 @@ module.exports = function (mongodbOplogUrl, options) {
         return mongoEntity
     }
 
+    function uncollapseSetObject(obj) {
+        const o = {};
+        Object.keys(obj).forEach((key) => {
+            const keysInKeyString = key.split('.');
+            const firstKey = keysInKeyString[0];
+            if (keysInKeyString.length === 1) {
+              o[firstKey] = obj[firstKey];
+            } else {
+                const restOfKeyString = key.substring(key.indexOf('.') + 1);
+                o[firstKey] = o[firstKey] || {};
+                o[firstKey][restOfKeyString] = obj[key];
+                o[firstKey] = uncollapseSetObject(o[firstKey]);
+            }
+        })
+        return o;
+    }
+
     function getData(chunk) {
         var data
-
         switch (chunk.op) {
             case 'i' :
                 data = deserialize(chunk.o)
                 break
             case 'u' :
-                data = chunk.o.$set
+                data = uncollapseSetObject(chunk.o.$set, {});
                 if (!data.id && chunk.o2 && chunk.o2._id) {
                     data.id = chunk.o2._id
                 }
@@ -169,7 +185,6 @@ module.exports = function (mongodbOplogUrl, options) {
             default :
                 data = {id:chunk.o._id}
         }
-
         return data
     }
 
@@ -189,7 +204,3 @@ module.exports = function (mongodbOplogUrl, options) {
     }
 
 }
-
-
-
-

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -113,7 +113,7 @@ exports.register = function (server, opts, next) {
                 onRouteRegister(schema)
                 const patchRoute = _.merge(routes.patch(schema), {
                     handler: (req, reply) => {
-                        reply(adapter.update(schema.type, req.params.id, req.payload.data).then((found)=> {
+                        reply(adapter.patch(schema.type, req.params.id, req.payload.data).then((found)=> {
                             if (found) {
                                 return {data: found}
                             } else {

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -134,7 +134,7 @@ module.exports = function () {
                 },
                 validate: {
                     params: schemaUtils.toJoiGetByIdPathValidation(),
-                    payload: schemaUtils.toJoiPostValidatation(schema)
+                    payload: schemaUtils.toJoiPostValidatation(schema, true)
                 }
             }
         }

--- a/lib/utils/schema.js
+++ b/lib/utils/schema.js
@@ -7,7 +7,7 @@ const idPattern = /[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f
 const idDescription = 'RFC4122 v4 UUID'
 
 module.exports = function () {
-    const toJoiPostValidatation = function (schema) {
+    const toJoiPostValidatation = function (schema, patch) {
         const relationshipsScheme = {};
         _.forEach(schema.relationships, function (item, key) {
             const isArray = _.isArray(item.data);
@@ -20,14 +20,28 @@ module.exports = function () {
               data: isArray ? Joi.array().items(itemSchema) : Joi.object().keys(itemSchema)
             });
         });
+        let dataType = Joi.string().valid(schema.type).required();
+        if (patch) {
+            schema.attributes = convertPostValidationToPatch(schema.attributes);
+            dataType = Joi.string().valid(schema.type);
+        }
         return Joi.object().keys({
             data: Joi.object().keys({
                 id: Joi.string().regex(idPattern).description(idDescription),
-                type: Joi.string().valid(schema.type).required(),
+                type: dataType,
                 attributes: schema.attributes,
                 relationships: relationshipsScheme
             }).required()
         })
+    }
+
+    const convertPostValidationToPatch = function (attributes) {
+        Object.keys(attributes).forEach(function(s) {
+            if (s && attributes[s] && attributes[s].isJoi && attributes[s]._flags && attributes[s]._flags.presence) {
+                attributes[s]._flags.presence = 'optional';
+            }
+        });
+        return attributes;
     }
 
     const createSingleRelationToPostPatch = function (type) {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "boom": "^2.9.0",
     "create-error": "^0.3.1",
     "debug": "^2.2.0",
+    "dot-object": "^1.4.1",
     "highland": "^2.5.1",
     "hoek": "^2.16.3",
     "http-as-promised": "^1.1.0",

--- a/test/rest.spec.js
+++ b/test/rest.spec.js
@@ -11,8 +11,8 @@ const schema = {
     brands: {
         type: 'brands',
         attributes: {
-            code: Joi.string().min(2).max(10),
-            description: Joi.string()
+            code: Joi.string().required().min(2).max(10),
+            description: Joi.string().required()
         }
     }
 };
@@ -34,37 +34,37 @@ describe('Rest operations when things go right', function() {
     });
 
     after(utils.createDefaultServerDestructor());
-    
+
     it('should set the content-type header to application/json by default', function() {
         return server.injectThen({method: 'GET', url: '/brands'})
         .then((res) => {
             expect(res.headers['content-type']).to.equal('application/json; charset=utf-8')
         })
     })
-    
+
     it('should allow all request with content-type set to application/json', function() {
         const headers = {
             'content-type' : 'application/json'
         }
-        
+
         server.injectThen({method: 'post', url: '/brands', headers: headers, payload: {data}})
             .then((res) => {
                 expect(res.statusCode).to.equal(201)
             })
     })
-    
+
     it('should allow all request with content-type set to application/vnd.api+json', function() {
         const headers = {
             'content-type' : 'application/vnd.api+json'
         }
-        
+
         server.injectThen({method: 'post', url: '/brands', headers: headers, payload: {data}})
-            
+
             .then((res) => {
                 expect(res.statusCode).to.equal(201)
             })
     })
-    
+
     it('Will be able to GET by id from /brands', function() {
         return server.injectThen({method: 'post', url: '/brands', payload: {data}})
         .then((res) => {
@@ -75,14 +75,14 @@ describe('Rest operations when things go right', function() {
             expect(utils.getData(res)).to.deep.equal(data)
         })
     })
-    
+
     it('Will be able to GET all from /brands', function() {
         let promises = [];
-        
+
         _.times(10, () => {
             promises.push(server.injectThen({method: 'post', url: '/brands', payload: {data}}))
         })
-        
+
         return Promise.all(promises)
         .then(() => {
             return server.injectThen({method: 'get', url: '/brands'})
@@ -90,34 +90,39 @@ describe('Rest operations when things go right', function() {
         .then((res) => {
             res.result.data.forEach((data) => {
                 expect(data.id).to.match(/[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}/)
-                expect(data).to.deep.equal(data)  
+                expect(data).to.deep.equal(data)
             })
         })
     })
-    
+
     it('Will be able to POST to /brands', function() {
         let payload = _.cloneDeep(data)
         payload.id = uuid.v4()
-        
+
         return server.injectThen({method: 'post', url: '/brands', payload: {data}}).then((res) => {
             expect(res.result.data.id).to.match(/[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}/)
             expect(utils.getData(res)).to.deep.equal(data)
         })
     })
-    
+
     it('Will be able to POST to /brands with uuid', function() {
         return server.injectThen({method: 'post', url: '/brands', payload: {data}}).then((res) => {
             expect(res.result.data.id).to.match(/[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}/)
             expect(utils.getData(res)).to.deep.equal(data)
         })
     })
-    
+
     it('Will be able to PATCH in /brands', function() {
         const payload = {
+            attributes: {
+                code: 'VT'
+            }
+        };
+        const expected = {
             type: 'brands',
             attributes: {
                 code: 'VT',
-                description: 'Valtra'
+                description: 'Massey Furgeson'
             }
         };
         return server.injectThen({method: 'post', url: '/brands', payload: {data}})
@@ -126,10 +131,10 @@ describe('Rest operations when things go right', function() {
         })
         .then((res) => {
             expect(res.result.data.id).to.match(/[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}/)
-            expect(utils.getData(res)).to.deep.equal(payload)
+            expect(utils.getData(res)).to.deep.equal(expected)
         })
     })
-    
+
     it('Will be able to DELETE in /brands', function() {
         return server.injectThen({method: 'post', url: '/brands', payload: {data}})
         .then((res) => {
@@ -148,9 +153,9 @@ describe('Rest operations when things go wrong', function() {
     });
 
     after(utils.createDefaultServerDestructor());
-    
+
     it('should reject all request with content-type not set to application/json or application/vnd.api+json', function() {
-        
+
         const headers = {
             'content-type' : 'text/html'
         }
@@ -159,12 +164,12 @@ describe('Rest operations when things go wrong', function() {
             expect(res.statusCode).to.equal(415)
         })
     })
-    
+
     it('Won\'t be able to POST to /brands with a payload that doesn\'t match the schema', function() {
-        
+
         let payload = _.cloneDeep(data);
         payload.foo = 'bar'
-        
+
         return server.injectThen({method: 'post', url: '/brands', payload: {data: payload}}).then((res) => {
             expect(res.statusCode).to.equal(400)
         })
@@ -179,23 +184,23 @@ describe('Rest operations when things go wrong', function() {
             expect(body.errors[0].validation.keys).to.include('data')
         })
     })
-    
+
     it('Won\'t be able to POST to /brands with a payload that doesn\'t have a type property', function() {
-        
+
         let payload = _.cloneDeep(data);
         delete payload.type
-        
+
         return server.injectThen({method: 'post', url: '/brands', payload: {data: payload}}).then((res) => {
             expect(res.statusCode).to.equal(400)
         })
     })
-    
+
     it('Won\'t be able to POST to /brands with an invalid uuid', function() {
-        
+
         let payload = _.cloneDeep(data);
         // has to match this /[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12}
         payload.id = '54ce70cd-9d0e-98e8-89c2-1423affcb0ca'
-        
+
         return server.injectThen({method: 'post', url: '/brands', payload: {data: payload}}).then((res) => {
             expect(res.statusCode).to.equal(400)
         })
@@ -220,17 +225,17 @@ describe('Rest operations when things go wrong', function() {
             expect(res.statusCode).to.equal(400)
         })
     })
-    
+
     it('Won\'t be able to POST to /brands with a payload that has attributes that don\'t match the schema', function() {
-        
+
         let payload = _.cloneDeep(data);
         payload.attributes.foo = 'bar'
-        
+
         return server.injectThen({method: 'post', url: '/brands', payload: {data: payload}}).then((res) => {
             expect(res.statusCode).to.equal(400)
         })
     })
-    
+
     it('Won\'t be able to GET by id from /brands if id is wrong', function() {
         return server.injectThen({method: 'post', url: '/brands', payload: {data}})
         .then(() => {
@@ -240,8 +245,8 @@ describe('Rest operations when things go wrong', function() {
             expect(res.statusCode).to.equal(404)
         })
     })
-    
-    it('Will be able to PATCH in /brands with wrong id', function() {
+
+    it('Won\'t be able to PATCH in /brands with wrong id', function() {
         const payload = {
             type: 'brands',
             attributes: {


### PR DESCRIPTION
This was more complicated than I originally thought:

- I updated the Joi validations by removing the required fields for PATCH.
- I modified the database update command to build out an object for updating only the provided fields (to prevent removal of existing fields that are not in the PATCH). This involved collapsing multi-level objects into flat object namespaces ( {a: {b: 1}} becomes {"a.b": 1} for $set ) (see https://docs.mongodb.org/manual/reference/operator/update/set/#set-fields-in-embedded-documents)
- I had to adjust SSE to reverse the object collapsing, so that the broadcasted update is not a flat namespaced object