### PR TITLE
Add optional 'required' array to schema, to mark attributes as required

### DIFF
--- a/lib/utils/schema.js
+++ b/lib/utils/schema.js
@@ -20,11 +20,15 @@ module.exports = function () {
               data: isArray ? Joi.array().items(itemSchema) : Joi.object().keys(itemSchema)
             });
         });
+        let attributes = Joi.object().keys(schema.attributes);
+        if (schema.required && schema.required instanceof Array && schema.required.indexOf('attributes') > -1) {
+          attributes = attributes.required();
+        }
         return Joi.object().keys({
             data: Joi.object().keys({
                 id: Joi.string().regex(idPattern).description(idDescription),
                 type: Joi.string().valid(schema.type).required(),
-                attributes: schema.attributes,
+                attributes,
                 relationships: relationshipsScheme
             }).required()
         })

--- a/test/rest.spec.js
+++ b/test/rest.spec.js
@@ -14,6 +14,14 @@ const schema = {
             code: Joi.string().min(2).max(10),
             description: Joi.string()
         }
+    },
+    widgets: {
+        type: 'widgets',
+        attributes: {
+            code: Joi.string().min(2).max(10),
+            description: Joi.string()
+        },
+        required: ['attributes']
     }
 };
 
@@ -25,46 +33,53 @@ const data = {
     }
 };
 
+const data2 = {
+    type: 'widgets',
+    attributes: {
+        code: 'WD',
+        description: 'Widget'
+    }
+};
+
 describe('Rest operations when things go right', function() {
 
     before(function () {
         return utils.buildDefaultServer(schema).then(function (server) {
-            return seeder(server).dropCollections('brands');
+            return seeder(server).dropCollections(['brands', 'widgets']);
         });
     });
 
     after(utils.createDefaultServerDestructor());
-    
+
     it('should set the content-type header to application/json by default', function() {
         return server.injectThen({method: 'GET', url: '/brands'})
         .then((res) => {
             expect(res.headers['content-type']).to.equal('application/json; charset=utf-8')
         })
     })
-    
+
     it('should allow all request with content-type set to application/json', function() {
         const headers = {
             'content-type' : 'application/json'
         }
-        
+
         server.injectThen({method: 'post', url: '/brands', headers: headers, payload: {data}})
             .then((res) => {
                 expect(res.statusCode).to.equal(201)
             })
     })
-    
+
     it('should allow all request with content-type set to application/vnd.api+json', function() {
         const headers = {
             'content-type' : 'application/vnd.api+json'
         }
-        
+
         server.injectThen({method: 'post', url: '/brands', headers: headers, payload: {data}})
-            
             .then((res) => {
                 expect(res.statusCode).to.equal(201)
             })
     })
-    
+
     it('Will be able to GET by id from /brands', function() {
         return server.injectThen({method: 'post', url: '/brands', payload: {data}})
         .then((res) => {
@@ -75,14 +90,14 @@ describe('Rest operations when things go right', function() {
             expect(utils.getData(res)).to.deep.equal(data)
         })
     })
-    
+
     it('Will be able to GET all from /brands', function() {
         let promises = [];
-        
+
         _.times(10, () => {
             promises.push(server.injectThen({method: 'post', url: '/brands', payload: {data}}))
         })
-        
+
         return Promise.all(promises)
         .then(() => {
             return server.injectThen({method: 'get', url: '/brands'})
@@ -90,28 +105,39 @@ describe('Rest operations when things go right', function() {
         .then((res) => {
             res.result.data.forEach((data) => {
                 expect(data.id).to.match(/[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}/)
-                expect(data).to.deep.equal(data)  
+                expect(data).to.deep.equal(data)
             })
         })
     })
-    
+
     it('Will be able to POST to /brands', function() {
         let payload = _.cloneDeep(data)
         payload.id = uuid.v4()
-        
+
         return server.injectThen({method: 'post', url: '/brands', payload: {data}}).then((res) => {
             expect(res.result.data.id).to.match(/[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}/)
             expect(utils.getData(res)).to.deep.equal(data)
         })
     })
-    
+
     it('Will be able to POST to /brands with uuid', function() {
         return server.injectThen({method: 'post', url: '/brands', payload: {data}}).then((res) => {
             expect(res.result.data.id).to.match(/[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}/)
             expect(utils.getData(res)).to.deep.equal(data)
         })
     })
-    
+
+    it('Will be able to POST in /brands without attributes', function() {
+        const payload = {
+            type: 'brands'
+        };
+        return server.injectThen({method: 'post', url: '/brands', payload: {data: payload}})
+        .then((res) => {
+            expect(res.result.data.id).to.match(/[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}/)
+            expect(utils.getData(res)).to.deep.equal(payload)
+        })
+    })
+
     it('Will be able to PATCH in /brands', function() {
         const payload = {
             type: 'brands',
@@ -129,7 +155,7 @@ describe('Rest operations when things go right', function() {
             expect(utils.getData(res)).to.deep.equal(payload)
         })
     })
-    
+
     it('Will be able to DELETE in /brands', function() {
         return server.injectThen({method: 'post', url: '/brands', payload: {data}})
         .then((res) => {
@@ -148,9 +174,9 @@ describe('Rest operations when things go wrong', function() {
     });
 
     after(utils.createDefaultServerDestructor());
-    
+
     it('should reject all request with content-type not set to application/json or application/vnd.api+json', function() {
-        
+
         const headers = {
             'content-type' : 'text/html'
         }
@@ -159,12 +185,12 @@ describe('Rest operations when things go wrong', function() {
             expect(res.statusCode).to.equal(415)
         })
     })
-    
+
     it('Won\'t be able to POST to /brands with a payload that doesn\'t match the schema', function() {
-        
+
         let payload = _.cloneDeep(data);
         payload.foo = 'bar'
-        
+
         return server.injectThen({method: 'post', url: '/brands', payload: {data: payload}}).then((res) => {
             expect(res.statusCode).to.equal(400)
         })
@@ -179,23 +205,23 @@ describe('Rest operations when things go wrong', function() {
             expect(body.errors[0].validation.keys).to.include('data')
         })
     })
-    
+
     it('Won\'t be able to POST to /brands with a payload that doesn\'t have a type property', function() {
-        
+
         let payload = _.cloneDeep(data);
         delete payload.type
-        
+
         return server.injectThen({method: 'post', url: '/brands', payload: {data: payload}}).then((res) => {
             expect(res.statusCode).to.equal(400)
         })
     })
-    
+
     it('Won\'t be able to POST to /brands with an invalid uuid', function() {
-        
+
         let payload = _.cloneDeep(data);
         // has to match this /[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12}
         payload.id = '54ce70cd-9d0e-98e8-89c2-1423affcb0ca'
-        
+
         return server.injectThen({method: 'post', url: '/brands', payload: {data: payload}}).then((res) => {
             expect(res.statusCode).to.equal(400)
         })
@@ -220,17 +246,17 @@ describe('Rest operations when things go wrong', function() {
             expect(res.statusCode).to.equal(400)
         })
     })
-    
+
     it('Won\'t be able to POST to /brands with a payload that has attributes that don\'t match the schema', function() {
-        
+
         let payload = _.cloneDeep(data);
         payload.attributes.foo = 'bar'
-        
+
         return server.injectThen({method: 'post', url: '/brands', payload: {data: payload}}).then((res) => {
             expect(res.statusCode).to.equal(400)
         })
     })
-    
+
     it('Won\'t be able to GET by id from /brands if id is wrong', function() {
         return server.injectThen({method: 'post', url: '/brands', payload: {data}})
         .then(() => {
@@ -240,7 +266,7 @@ describe('Rest operations when things go wrong', function() {
             expect(res.statusCode).to.equal(404)
         })
     })
-    
+
     it('Will be able to PATCH in /brands with wrong id', function() {
         const payload = {
             type: 'brands',
@@ -257,4 +283,15 @@ describe('Rest operations when things go wrong', function() {
             expect(res.statusCode).to.equal(404)
         })
     })
+
+    it('Won\'t able to POST in /widgets without attributes', function() {
+        const payload = {
+            type: 'widgets'
+        };
+        return server.injectThen({method: 'post', url: '/widgets', payload: {data: payload}})
+        .then((res) => {
+            expect(res.statusCode).to.equal(400)
+        })
+    })
+
 })

--- a/test/utils.js
+++ b/test/utils.js
@@ -36,7 +36,8 @@ var utils = {
             }, require('susie'), require('inject-then')
             ], () => {
                 let harvester = server.plugins['hapi-harvester'];
-                server.start(() => {
+                server.start((err) => {
+                    if (err) console.error(err);
                     _.forEach(schemas, function (schema) {
 
                         const route = harvester.routes.all(schema)


### PR DESCRIPTION
Add optional 'required' array to schema, to mark attributes as required. 
Could be used to require relationships, etc in the future.