### PR TITLE
Improving mongoose->mongodb dependency chain requirement.

### DIFF
--- a/lib/adapters/mongodb/sse/index.js
+++ b/lib/adapters/mongodb/sse/index.js
@@ -5,7 +5,7 @@ const Hoek = require('hoek')
 const Promise = require('bluebird')
 const Rx = require('rx')
 const RxNode = require('rx-node')
-const mongo = require('mongoose/node_modules/mongodb')
+const mongo = require('mongodb')
 const mongoose = require('mongoose')
 const Boom = require('boom')
 
@@ -189,7 +189,3 @@ module.exports = function (mongodbOplogUrl, options) {
     }
 
 }
-
-
-
-

--- a/lib/utils/adapter.js
+++ b/lib/utils/adapter.js
@@ -8,7 +8,7 @@ module.exports = function() {
     const _checkValidAdapter = function(adapter, protocolFunctions) {
 
         Hoek.assert(adapter, new Error('adapter missing'))
-        
+
         protocolFunctions.forEach((func) => {
             Hoek.assert(adapter[func], new Error('Adapter validation failed. Adapter missing ' + func));
         })
@@ -27,7 +27,7 @@ module.exports = function() {
             try {
                 return require('../../lib/adapters/' + adapter);
             } catch (err) {
-                Hoek.assert(!err, new Error('Wrong adapter name, see docs for built in adapter'))
+                Hoek.assert(!err, new Error('Unexpected error when loading adapter ' + adapter))
             }
         }
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "http-as-promised": "^1.1.0",
     "joi": "^6.9.0",
     "lodash": "^3.10.1",
+    "mongodb": "^2.1.7",
     "mongoose": "^4.2.8",
     "node-uuid": "^1.4.3",
     "qs": "^6.0.0",


### PR DESCRIPTION
After starting a project from scratch, I started to receive the following error message:

```
Wrong adapter name, see docs for built in adapter
```

Actually that happens because SSE adapter assumes that required mongodb module is located inside mongoose folder tree. This is a bad practice because if the target project has it as a dependency, it won't be downloaded into mongoose node-modules folder.

So, in order to make this "friendly" for dev community and save some hours of debugging for who is beginning with HH, I'm submitting two improvements:
#1: Add mongodb as module as a dependency for hapi-harvester and require it directly, w/o a specific path (to avoid issues when it was required already).
#2: Changed the error message when loading adapters to be friendly (because it induces the wrong direction when debugging).  The matter fact is that exception is thrown when  HH can't load an adapter, because it doesn't exist or because an error occurred. Still wondering how to expose the error message to tell the developer what happened exactly.
