### PR TITLE
make sse features and adapter setup optional

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 mongo1:
   hostname: mongo1
-  image: mongo:3
+  image: mongo:3.2.4
   entrypoint: [ "mongod", "--replSet", "rs", "--journal", "--smallfiles", "--rest" ]
   ports:
     - "27017:27017"
@@ -9,7 +9,7 @@ mongo1:
 
 # This configures the MongoDB replicaset
 mongosetup:
-  image: mongo:3
+  image: mongo:3.2.4
   links:
     - mongo1:mongo1
   volumes:
@@ -19,7 +19,7 @@ mongosetup:
 # Verify reading and writing
 # Run 'docker logs -f elasticmongo_verify_1' to see what it outputs.
 verify:
-  image: mongo:3
+  image: mongo:3.2.4
   links:
     - mongo1:mongo1
   volumes:
@@ -27,7 +27,7 @@ verify:
   entrypoint: [ "/scripts/query.sh" ]
 
 msh:
-  image: mongo:3
+  image: mongo:3.2.4
   links:
     - mongo1:mongo1
   command: mongo --host mongo1

--- a/docker/scripts/query.sh
+++ b/docker/scripts/query.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+apt-get update
+apt-get install -y curl
+
 MONGODB1=`ping -c 1 mongo1 | head -1  | cut -d "(" -f 2 | cut -d ")" -f 1`
 
 /scripts/wait-until-started.sh

--- a/docker/scripts/setup.sh
+++ b/docker/scripts/setup.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+apt-get update
+apt-get install -y curl
+
 MONGODB1=`ping -c 1 mongo1 | head -1  | cut -d "(" -f 2 | cut -d ")" -f 1`
 
 echo "Waiting for startup.."

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -15,27 +15,34 @@ const debug = require('debug')('hh-plugin')
 exports.register = function (server, opts, next) {
     server.expose('version', require('../package.json').version);
 
+    const adapters = []
+
     const adapter = opts.adapter
     adapterUtils.checkValidAdapter(adapter)
     server.expose('adapter', adapter)
+    adapters.push(adapter)
 
     const adapterSSE = opts.adapterSSE
-    adapterUtils.checkValidAdapterSSE(adapterSSE)
-    server.expose('adapterSSE', adapterSSE)
+    if (adapterSSE) {
+        adapterUtils.checkValidAdapterSSE(adapterSSE)
+        server.expose('adapterSSE', adapterSSE)
+        adapters.push(adapterSSE)
 
-    Promise.all([
-            adapter.connect(),
-            adapterSSE.connect()
-        ])
+        server.dependency('susie')
+    }
+
+    Promise.all(_.map(adapters, (adapter)=>adapter.connect()))
         .then(()=> {
 
-            server.route({
-                method: 'get',
-                path: '/changes/streaming',
-                handler: sse({
-                    context: server
+            if (adapterSSE) {
+                server.route({
+                    method: 'get',
+                    path: '/changes/streaming',
+                    handler: sse({
+                        context: server
+                    })
                 })
-            })
+            }
 
             const schemas = {};
 
@@ -92,6 +99,7 @@ exports.register = function (server, opts, next) {
 
             const getChangesStreaming = function (schema) {
                 onRouteRegister(schema)
+                Hoek.assert(adapterSSE, 'getChangesStreaming can not be invoked, adapterSSE is not set')
                 return _.merge(routes.getChangesStreaming(schema), {
                     handler: sse({
                         context: server,
@@ -181,7 +189,15 @@ exports.register = function (server, opts, next) {
                 options: options
             }
 
-            const allLabels = ['get', 'getById', 'getChangesStreaming', 'post', 'patch', 'delete', 'options']
+            const allLabels = constructLabels()
+
+            function constructLabels() {
+                const labels = ['get', 'getById', 'post', 'patch', 'delete', 'options']
+                if (adapterSSE) {
+                    labels.push('getChangesStreaming')
+                }
+                return labels
+            }
 
             const all = function (schema) {
                 return _.chain(allLabels)
@@ -386,10 +402,7 @@ exports.register = function (server, opts, next) {
             })
 
             server.ext('onPostStop', (server, next) => {
-                Promise.all([
-                        adapter.disconnect(),
-                        adapterSSE.disconnect()
-                    ])
+                Promise.all(_.map(adapters, (adapter)=>adapter.disconnect()))
                     .then(()=> {
                         next()
                     })

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -94,7 +94,7 @@ function buildServerSetupWithAdapters(adapter, adapterSSE) {
                 adapterSSE: adapterSSE
             }
             },
-            {register: require('inject-then')}
+            require('susie'), require('inject-then')
         ], () => {
             server.start((err)=> {
                 if (err) {

--- a/test/utils.js
+++ b/test/utils.js
@@ -38,16 +38,8 @@ var utils = {
                 let harvester = server.plugins['hapi-harvester'];
                 server.start(() => {
                     _.forEach(schemas, function (schema) {
-
-                        const route = harvester.routes.all(schema)
-                        if (_.isArray(route)) {
-                            _.forEach(route, function (route) {
-                                server.route(route)
-                            });
-                        } else {
-                            server.route(route)
-                        }
-
+                        const routes = harvester.routes.all(schema)
+                        _.forEach(routes, (route) => server.route(route))
                     });
                     resolve({server, harvester})
                 })


### PR DESCRIPTION
Currently hapi-harvester only initialises when both adapter and adapterSSE are provided, this is annoying when you have an app which doesn't require SSE. 

This PR gets rid of the adapterSSE requirement and errors in case routes.getChangesStreaming is invoked, the routes.all also doesn't return a route definition for getChangesStreaming  

Note for this PR to build successfully in Travis I had to fix a couple of things in the docker-compose.yml and setup scripts.