### PR TITLE
Fixes dependency break on recent npm versions.

### DIFF
--- a/docker/scripts/query.sh
+++ b/docker/scripts/query.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+echo "installing curl..."
+apt-get update
+apt-get install -y curl
+
 MONGODB1=`ping -c 1 mongo1 | head -1  | cut -d "(" -f 2 | cut -d ")" -f 1`
 
 /scripts/wait-until-started.sh

--- a/lib/adapters/mongodb/sse/index.js
+++ b/lib/adapters/mongodb/sse/index.js
@@ -5,7 +5,7 @@ const Hoek = require('hoek')
 const Promise = require('bluebird')
 const Rx = require('rx')
 const RxNode = require('rx-node')
-const mongo = require('mongoose/node_modules/mongodb')
+const mongo = require('mongodb')
 const mongoose = require('mongoose')
 const Boom = require('boom')
 

--- a/lib/utils/adapter.js
+++ b/lib/utils/adapter.js
@@ -27,7 +27,7 @@ module.exports = function() {
             try {
                 return require('../../lib/adapters/' + adapter);
             } catch (err) {
-                Hoek.assert(!err, new Error('Wrong adapter name, see docs for built in adapter'))
+                Hoek.assert(!err, new Error('Unexpected error when loading adapter ' + adapter))
             }
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-harvester",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Harvester Hapi Plugin",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "http-as-promised": "^1.1.0",
     "joi": "^6.9.0",
     "lodash": "^3.10.1",
+    "mongodb": "2.1.16",
     "mongoose": "^4.2.8",
     "node-uuid": "^1.4.3",
     "qs": "^6.0.0",


### PR DESCRIPTION
This change adds an explicit dependency to the mongodb package and removes the dependency from the internal mongoose reference (in mongoose/node_modules/mongodb)
