### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/adapters/mongodb/converters.js
+++ b/lib/adapters/mongodb/converters.js
@@ -3,7 +3,7 @@
 const Hapi = require('hapi')
 const _ = require('lodash')
 const Hoek = require('hoek')
-const uuid = require('node-uuid')
+const uuid = require('uuid')
 const mongoose = require('mongoose')
 
 module.exports = function() {

--- a/package.json
+++ b/package.json
@@ -35,11 +35,11 @@
     "lodash": "^3.10.1",
     "mongodb": "2.1.16",
     "mongoose": "^4.2.8",
-    "node-uuid": "^1.4.3",
     "qs": "^6.0.0",
     "rx": "^4.0.7",
     "rx-node": "^1.0.1",
-    "susie": "^1.0.1"
+    "susie": "^1.0.1",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "agco-event-source-stream": "^1.1.1",

--- a/test/rest.spec.js
+++ b/test/rest.spec.js
@@ -4,7 +4,7 @@ const _ = require('lodash')
 const Promise = require('bluebird')
 const Joi = require('joi')
 const utils = require('./utils');
-const uuid = require('node-uuid')
+const uuid = require('uuid')
 const seeder = require('./seeder');
 
 const schema = {


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.